### PR TITLE
Clip to bounds detail view content

### DIFF
--- a/iOS-Viper-Architecture/Base.lproj/Main.storyboard
+++ b/iOS-Viper-Architecture/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="WSu-YL-dXu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="WSu-YL-dXu">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,7 +17,7 @@
                         <viewControllerLayoutGuide type="top" id="OFz-HC-hD2"/>
                         <viewControllerLayoutGuide type="bottom" id="y6d-uU-Rzq"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="uAK-FY-fN1">
+                    <view key="view" clipsSubviews="YES" contentMode="scaleToFill" id="uAK-FY-fN1">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -165,7 +165,7 @@
                 <navigationController storyboardIdentifier="PostsNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="WSu-YL-dXu" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Mxg-8K-exu">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>


### PR DESCRIPTION
Clip to bounds detail view content so it's image view won't overlap PostList when popping.
<img width="404" alt="screen shot 2017-10-08 at 23 40 54" src="https://user-images.githubusercontent.com/26486594/31319786-972750b0-ac82-11e7-8376-318503151252.png">
<img width="399" alt="screen shot 2017-10-08 at 23 43 07" src="https://user-images.githubusercontent.com/26486594/31319785-97237436-ac82-11e7-908a-bae00348db80.png">

